### PR TITLE
Quick fix for YAML document parsing bug regarding supported Swagger version numbers

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -14,7 +14,12 @@ var defaults = require('./defaults');
 var State = require('./state');
 var util = require('./util');
 
-var supportedSwaggerVersions = ['2.0'];
+/*
+ * Added a numeric type of the version into the array,
+ * as the YAML parser reads it as a number and the 
+ * verification fails. 
+ */
+var supportedSwaggerVersions = ['2.0', 2];
 
 
 /**


### PR DESCRIPTION
The YAML parser reads the Swagger version attribute as a number and the verification test fails, i.e. 
shows an incompatible version as it cannot find a numeric version in supportedSwaggerVersions array.

This sample document fails the version support check https://raw.githubusercontent.com/appirio-tech/lc1-challenge-service/85160966dbf2cc9a0023e185a8fb99f5c98b9e86/api/swagger/swagger.yaml.

Although the Swagger version attribute has a value of 2.0, the YAML parser converts it to a number -> 2.  Normally, this should be fixed on the parsing side of things, but I've played a bit with the parser myself and did not find any option that fixes this issue.
