### PR TITLE
Workaround for '$ref' property name.

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -2,12 +2,13 @@
 
 module.exports = resolve;
 
-var read      = require('./read'),
-    util      = require('./util'),
-    _last     = require('lodash/array/last'),
-    _result   = require('lodash/object/result'),
-    _has      = require('lodash/object/has'),
-    _isEmpty  = require('lodash/lang/isEmpty');
+var read           = require('./read'),
+    util           = require('./util'),
+    _last          = require('lodash/array/last'),
+    _result        = require('lodash/object/result'),
+    _has           = require('lodash/object/has'),
+    _isEmpty       = require('lodash/lang/isEmpty'),
+    _isPlainObject = require('lodash/lang/isPlainObject');
 
 
 // RegExp pattern to detect external $ref pointers.
@@ -68,7 +69,7 @@ function resolveObject(obj, objPath, state, callback) {
  * @param   {function}  callback
  */
 function resolveIf$Ref(value, valuePath, state, callback) {
-    if (_has(value, '$ref')) {
+    if (_has(value, '$ref') && !_isPlainObject(value.$ref)) {
         if (isExternal$Ref(value.$ref) && !state.options.resolveExternal$Refs) {
             // Resolving external pointers is disabled, so return the $ref as-is
             util.doCallback(callback, null, value);


### PR DESCRIPTION
Property could have '$ref' name it's valid name.
Moreover such swagger files exist in the wild see [swagger] (https://github.com/APIs-guru/api-models/blob/master/google/discovery/v1/swagger.json#L225) for Google Discovery service.
It would be common problem for any API which return json-schema.
I implement workaround it solve problem but in the same time allowing incorrect references.
I understand that for proper reference detection you need to re-implement half of your library.
In any case it should be addressed in FAQ