### PR TITLE
Added support for downloading remote files over https

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -5,6 +5,7 @@ module.exports = read;
 var fs          = require('fs'),
     Path        = require('path'),
     http        = require('http'),
+    https       = require('https'),
     url         = require('url'),
     yaml        = require('js-yaml'),
     util        = require('./util'),
@@ -102,7 +103,14 @@ function readUrl(parsedUrl, state, callback) {
 
     util.debug('Downloading file "%s"', parsedUrl.href);
 
-    var req = http.get(options, function(res) {
+    if (parsedUrl.protocol == 'https:') {
+      var req = https;
+    }
+    else {
+      var req = http;
+    }
+
+    req = req.get(options, function(res) {
       var body = '';
 
       res.on('data', function(data) {


### PR DESCRIPTION
Fixes #10

Could be worth considering the popular [request](https://www.npmjs.com/package/request) module which supports with a simple DSL syntax.