### PR TITLE
[Do not merge] Migrate APIs.guru related URLs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Swagger Parser v3.4
 [![Code Climate Score](https://codeclimate.com/github/BigstickCarpet/swagger-parser/badges/gpa.svg)](https://codeclimate.com/github/BigstickCarpet/swagger-parser)
 [![Codacy Score](https://www.codacy.com/project/badge/6d686f916836433b9c013379fbe1052c)](https://www.codacy.com/public/jamesmessinger/swagger-parser)
 [![Inline docs](http://inch-ci.org/github/BigstickCarpet/swagger-parser.svg?branch=master&style=shields)](http://inch-ci.org/github/BigstickCarpet/swagger-parser)
+[![Tested on APIs.guru](https://api.apis.guru/badges/tested_on.svg)](https://APIs.guru)
 
 [![npm](http://img.shields.io/npm/v/swagger-parser.svg)](https://www.npmjs.com/package/swagger-parser)
 [![Bower](http://img.shields.io/bower/v/swagger-parser.svg)](http://bower.io/)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Features
 - Can [dereference](docs/swagger-parser.md#dereferenceapi-options-callback) all `$ref` pointers, giving you a normal JavaScript object that's easy to work with
 - Configurable caching of external files and URLs
 - **[Tested](http://bigstickcarpet.github.io/swagger-parser/tests/index.html)** in Node, IO.js, and all modern web browsers on Mac, Windows, Linux, iOS, and Android
-- Tested on **[over 200 real-world APIs](https://github.com/APIs-guru/api-models)** from Google, Instagram, Cisco, etc.
+- Tested on **[over 200 real-world APIs](https://apis.guru)** from Google, Instagram, Cisco, etc.
 - Supports [circular references](docs/README.md#circular-refs), nested references, back-references, and cross-references
 - Maintains object reference equality &mdash; `$ref` pointers to the same value always resolve to the same object instance
 

--- a/tests/specs/real-world/real-world.spec.js
+++ b/tests/specs/real-world/real-world.spec.js
@@ -6,7 +6,7 @@ describe('Real-world APIs', function() {
 
   before(function(done) {
     // Download a list of over 200 real-world Swagger APIs from apis.guru
-    superagent.get('http://apis-guru.github.io/api-models/api/v1/list.json')
+    superagent.get('https://api.apis.guru/v2/list.json')
       .end(function(err, res) {
         if (err || !res.ok) {
           return done(err || new Error('Unable to downlaod real-world APIs from apis.guru'));

--- a/tests/specs/real-world/real-world.spec.js
+++ b/tests/specs/real-world/real-world.spec.js
@@ -6,7 +6,7 @@ describe('Real-world APIs', function() {
 
   before(function(done) {
     // Download a list of over 200 real-world Swagger APIs from apis.guru
-    superagent.get('https://api.apis.guru/v2/list.json')
+    superagent.get('https://s3.amazonaws.com/api.apis.guru/v2/list.json')
       .end(function(err, res) {
         if (err || !res.ok) {
           return done(err || new Error('Unable to downlaod real-world APIs from apis.guru'));


### PR DESCRIPTION
Hi @BigstickCarpet,

We are migrating our URLs to `APIs.guru` domain, here is more details:
https://github.com/APIs-guru/api-models/issues/85
Plus I add `Tested on APIs.guru` badge, hope you will like it :smile: 
[![Tested on APIs.guru](https://api.apis.guru/badges/tested_on.svg)](https://APIs.guru)