### PR TITLE
Fix swagger-schema-official JSON import

### DIFF
--- a/lib/validate-schema.js
+++ b/lib/validate-schema.js
@@ -3,7 +3,7 @@
 var util          = require('./util'),
     ono           = require('ono'),
     ZSchema       = require('z-schema'),
-    swaggerSchema = require('swagger-schema-official/schema');
+    swaggerSchema = require('swagger-schema-official/schema.json');
 
 module.exports = validateSchema;
 


### PR DESCRIPTION
I ran into an issue with swagger-parser using node v7.5.0 and Typescript 2.1.6 where `swagger-schema-official/schema` couldn't be required. Adding `.json` to the require statement fixes the problem.