### PR TITLE
[v4] Check parameter properties based on type validity

### DIFF
--- a/lib/validate-spec.js
+++ b/lib/validate-spec.js
@@ -1,10 +1,13 @@
 'use strict';
 
-var util           = require('./util'),
-    ono            = require('ono'),
-    swaggerMethods = require('swagger-methods'),
-    primitiveTypes = ['array', 'boolean', 'integer', 'number', 'string'],
-    schemaTypes    = ['array', 'boolean', 'integer', 'number', 'string', 'object', 'null', undefined];
+var util              = require('./util'),
+    ono               = require('ono'),
+    swaggerMethods    = require('swagger-methods'),
+    primitiveTypes    = ['array', 'boolean', 'integer', 'number', 'string'],
+    schemaTypes       = ['array', 'boolean', 'integer', 'number', 'string', 'object', 'null', undefined],
+    numericProperties = ['minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum', 'multipleOf'],
+    stringProperties  = ['minLength', 'maxLength', 'pattern'],
+    arrayProperties   = ['minItems', 'maxItems', 'uniqueItems'];
 
 module.exports = validateSpec;
 
@@ -216,6 +219,38 @@ function validateParameterTypes(params, api, operation, operationId) {
         );
       }
     }
+
+    var isNumeric = ((param.type == 'integer') || (param.type == 'number'));
+    if (!isNumeric) {
+      numericProperties.forEach(function(prop){
+        if (typeof param[prop] !== 'undefined') {
+          throw ono.syntax(
+            'Parameter %s is type %s, therefore cannot have a %s property',
+            param.name, param.type, prop);
+        }
+      });
+    }
+
+    if (param.type !== 'string') {
+      stringProperties.forEach(function(prop){
+        if (typeof param[prop] !== 'undefined') {
+          throw ono.syntax(
+            'Parameter %s is type %s, therefore cannot have a %s property',
+            param.name, param.type, prop);
+          }
+      });
+    }
+
+    if (param.type !== 'array') {
+      arrayProperties.forEach(function(prop){
+        if (typeof param[prop] !== 'undefined') {
+          throw ono.syntax(
+            'Parameter %s is type %s, therefore cannot have a %s property',
+            param.name, param.type, prop);
+        }
+      });
+    }
+
   });
 }
 


### PR DESCRIPTION
This change checks the following properties against the parameter `type`s they are valid for:

* minimum
* maximum
* exclusiveMinimum
* exclusiveMaximum
* multipleOf
* minLength
* maxLength
* pattern
* minItems
* maxItems
* uniqueItems