### PR TITLE
Changes schema path to schema.json

### DIFF
--- a/lib/validate-schema.js
+++ b/lib/validate-schema.js
@@ -3,7 +3,7 @@
 var util          = require('./util'),
     ono           = require('ono'),
     ZSchema       = require('z-schema'),
-    swaggerSchema = require('swagger-schema-official/schema');
+    swaggerSchema = require('swagger-schema-official/schema.json');
 
 module.exports = validateSchema;
 


### PR DESCRIPTION
`require('swagger-schema-official/schema')` doesn't resolve when using webpack. By changing to `require('swagger-schema-official/schema.json')`, the spec resolves.