### PR TITLE
Issue 73: ensure responses is populated with an object

### DIFF
--- a/lib/validate-spec.js
+++ b/lib/validate-spec.js
@@ -48,7 +48,7 @@ function validatePath (api, path, pathId) {
       responses.forEach(function (responseName) {
         var response = operation.responses[responseName];
         var responseId = operationId + '/responses/' + responseName;
-        validateResponse(responseName, response, responseId);
+        validateResponse(responseName, (response || {}), responseId);
       });
     }
   });


### PR DESCRIPTION
https://github.com/BigstickCarpet/swagger-parser/issues/73

This issue accounts for instances where there are extensions in the responses object and those extensions can be null. 