### PR TITLE
Accept vendor specific versions of consumes types for file params

### DIFF
--- a/lib/validators/spec.js
+++ b/lib/validators/spec.js
@@ -219,8 +219,9 @@ function validateParameterTypes (params, api, operation, operationId) {
     if (schema.type === 'file') {
       // "file" params require specific "consumes" types
       var consumes = operation.consumes || api.consumes || [];
-      if (consumes.indexOf('multipart/form-data') === -1 &&
-        consumes.indexOf('application/x-www-form-urlencoded') === -1) {
+      if (!consumes.some(function (consume) {
+        return /multipart\/(.*\+)?form-data/.test(consume) || /application\/(.*\+)?x-www-form-urlencoded/.test(consume);
+      })) {
         throw ono.syntax(
           'Validation failed. %s has a file parameter, so it must consume multipart/form-data ' +
           'or application/x-www-form-urlencoded',

--- a/test/specs/validate-spec/valid/file-vendor-specific-consumes-formdata.yaml
+++ b/test/specs/validate-spec/valid/file-vendor-specific-consumes-formdata.yaml
@@ -1,0 +1,21 @@
+swagger: "2.0"
+info:
+  version: "1.0.0"
+  title: Valid API
+
+paths:
+  /users/{username}/profile/image:
+    parameters:
+      - name: username
+        in: path
+        type: string
+        required: true
+      - name: image
+        in: formData
+        type: file      # <--- "file" params REQUIRE multipart/form-data or application/x-www-form-urlencoded
+    post:
+      consumes:
+        - multipart/vnd.specific+form-data;version=1.0    # <--- Vendor specific version of multipart/form-data with a parameter
+      responses:
+        default:
+          description:  hello world

--- a/test/specs/validate-spec/valid/file-vendor-specific-consumes-urlencoded.yaml
+++ b/test/specs/validate-spec/valid/file-vendor-specific-consumes-urlencoded.yaml
@@ -1,0 +1,21 @@
+swagger: "2.0"
+info:
+  version: "1.0.0"
+  title: Valid API
+
+paths:
+  /users/{username}/profile/image:
+    parameters:
+      - name: username
+        in: path
+        type: string
+        required: true
+      - name: image
+        in: formData
+        type: file      # <--- "file" params REQUIRE multipart/form-data or application/x-www-form-urlencoded
+    post:
+      consumes:
+        - application/vnd.specific+x-www-form-urlencoded;version=1.0    # <--- Vendor specific version of application/x-www-form-urlencoded with a parameter
+      responses:
+        default:
+          description:  hello world

--- a/test/specs/validate-spec/validate-spec.spec.js
+++ b/test/specs/validate-spec/validate-spec.spec.js
@@ -99,6 +99,16 @@ describe('Invalid APIs (Swagger 2.0 specification validation)', function () {
       error: 'Validation failed. /paths/users/{username}/profile/image/post has a file parameter, so it must consume multipart/form-data or application/x-www-form-urlencoded'
     },
     {
+      name: '"file" param with vendor specific form-data "consumes"',
+      valid: true,
+      file: 'file-vendor-specific-consumes-formdata.yaml'
+    },
+    {
+      name: '"file" param with vendor specific urlencoded "consumes"',
+      valid: true,
+      file: 'file-vendor-specific-consumes-urlencoded.yaml'
+    },
+    {
       name: 'required property in input does not exist',
       valid: false,
       file: 'required-property-not-defined-input.yaml',


### PR DESCRIPTION
Replaced the hard coded media type strings with regexes that allow for
vendor specific versions of the types to make things a bit more
flexible.